### PR TITLE
added function to track active users

### DIFF
--- a/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
+++ b/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
@@ -165,6 +165,7 @@ class ColumnNames(Enum):
         QUESTION_ID: The unique identifier for a specific question within the questionnaire.
         QUESTION_TEXT: The text or content of the question being asked.
         ANSWER_TEXT: The text or content of the respondent's answer.
+        LAST_USER_INTERACTION: The datetime of a user's most recent recorded interaction.
     """
 
     USER_ID = "UserId"
@@ -192,6 +193,7 @@ class ColumnNames(Enum):
     ANSWER_TEXT = "AnswerText"
     RISK_SCORE = "RiskScore"
     SCORE_INTERPRETATION = "ScoreInterpretation"
+    LAST_USER_INTERACTION = "LastUserInteraction"
 
 
 # pylint: disable=too-few-public-methods

--- a/src/spezi_data_pipeline/data_processing/data_processor.py
+++ b/src/spezi_data_pipeline/data_processing/data_processor.py
@@ -313,3 +313,24 @@ def select_data_by_dates(  # pylint: disable=unused-variable
         filtered_df.reset_index(drop=True),
         resource_type=flattened_fhir_dataframe.resource_type,
     )
+
+def extract_latest_user_interaction(  # pylint: disable=unused-variable
+    flattend_fhir_df: pd.DataFrame
+    )->None:
+    """
+    Extracts the latest interaction of each user from a flattened fhir DataFrame and saves results to a CSV file. 
+    Parameters:
+        flattend_fhir_df (pd.DataFrame): The flattened_fhir `DataFrame`.
+    """
+    #Base case
+    if flattend_fhir_df.empty:
+        return
+
+    #First convert column to datetime for comparison
+    flattend_fhir_df['EffectiveDateTime'] = pd.to_datetime(flattend_fhir_df['EffectiveDateTime'], format='%d.%m.%y')
+    #Filter the most recent entry for each userid 
+    most_recent_df=flattend_fhir_df.loc[flattend_fhir_df.groupby('UserId')['EffectiveDateTime'].idxmax()]
+    most_recent_df=most_recent_df[['UserId','EffectiveDateTime']]#select the relevant cols
+    most_recent_df.rename(columns={'EffectiveDateTime': 'LastUserInteraction'}, inplace=True)
+    most_recent_df.to_csv('output.csv')
+    return

--- a/src/spezi_data_pipeline/data_processing/data_processor.py
+++ b/src/spezi_data_pipeline/data_processing/data_processor.py
@@ -19,6 +19,8 @@ Key Features:
     health data metrics.
 - `select_data_by_user` and `select_data_by_dates`: Utility functions that facilitate the filtering
     of FHIR data based on user IDs and date ranges, respectively.
+- `extract_latest_user_interaction`: Utility function that summarizes the most recent interaction
+    recorded for each user, optionally exporting the result to a CSV file.
 - Code mappings and processing functions: Mechanisms for associating LOINC codes with specific
     processing routines and value ranges, enabling targeted and meaningful analysis of healthcare
     metrics.
@@ -314,23 +316,56 @@ def select_data_by_dates(  # pylint: disable=unused-variable
         resource_type=flattened_fhir_dataframe.resource_type,
     )
 
-def extract_latest_user_interaction(  # pylint: disable=unused-variable
-    flattend_fhir_df: pd.DataFrame
-    )->None:
-    """
-    Extracts the latest interaction of each user from a flattened fhir DataFrame and saves results to a CSV file. 
-    Parameters:
-        flattend_fhir_df (pd.DataFrame): The flattened_fhir `DataFrame`.
-    """
-    #Base case
-    if flattend_fhir_df.empty:
-        return
 
-    #First convert column to datetime for comparison
-    flattend_fhir_df['EffectiveDateTime'] = pd.to_datetime(flattend_fhir_df['EffectiveDateTime'], format='%d.%m.%y')
-    #Filter the most recent entry for each userid 
-    most_recent_df=flattend_fhir_df.loc[flattend_fhir_df.groupby('UserId')['EffectiveDateTime'].idxmax()]
-    most_recent_df=most_recent_df[['UserId','EffectiveDateTime']]#select the relevant cols
-    most_recent_df.rename(columns={'EffectiveDateTime': 'LastUserInteraction'}, inplace=True)
-    most_recent_df.to_csv('output.csv')
-    return
+def extract_latest_user_interaction(  # pylint: disable=unused-variable
+    flattened_fhir_dataframe: FHIRDataFrame,
+    output_file_path: str | None = None,
+) -> pd.DataFrame:
+    """
+    Extracts the most recent interaction of each user from a FHIRDataFrame.
+
+    For each user, the row with the latest effective datetime is identified, producing a
+    summary of when every user was last active. The result is optionally written to a CSV file.
+
+    Parameters:
+        flattened_fhir_dataframe (FHIRDataFrame): The FHIRDataFrame from which to extract the
+            latest user interactions.
+        output_file_path (str | None): The path of the CSV file to which the result is
+            written. If None (the default), no file is created.
+
+    Returns:
+        pd.DataFrame: A DataFrame with one row per user containing the user identifier and the
+            datetime of their most recent interaction.
+    """
+    result_columns = [
+        ColumnNames.USER_ID.value,
+        ColumnNames.LAST_USER_INTERACTION.value,
+    ]
+
+    if flattened_fhir_dataframe.df.empty:
+        return pd.DataFrame(columns=result_columns)
+
+    working_df = flattened_fhir_dataframe.df.copy()
+    working_df[ColumnNames.EFFECTIVE_DATE_TIME.value] = pd.to_datetime(
+        working_df[ColumnNames.EFFECTIVE_DATE_TIME.value]
+    )
+
+    latest_interaction_df = (
+        working_df.groupby(ColumnNames.USER_ID.value)[
+            ColumnNames.EFFECTIVE_DATE_TIME.value
+        ]
+        .max()
+        .reset_index()
+        .rename(
+            columns={
+                ColumnNames.EFFECTIVE_DATE_TIME.value: (
+                    ColumnNames.LAST_USER_INTERACTION.value
+                )
+            }
+        )
+    )
+
+    if output_file_path is not None:
+        latest_interaction_df.to_csv(output_file_path, index=False)
+
+    return latest_interaction_df

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -20,7 +20,14 @@ The module defines the following unit test classes:
    - Selecting data by user ID.
    - Selecting data by date range.
 
-2. `TestCalculateRiskScore`: Tests for `calculate_risk_score` function, including:
+2. `TestExtractLatestUserInteraction`: Tests for `extract_latest_user_interaction` function,
+   including:
+   - Extracting the latest interaction per user.
+   - Ensuring the input DataFrame is not mutated.
+   - Writing the result to a configurable CSV file.
+   - Handling empty input.
+
+3. `TestCalculateRiskScore`: Tests for `calculate_risk_score` function, including:
    - Calculating risk scores for PHQ-9, GAD-7, and WIQ questionnaires.
    - Handling unsupported questionnaires.
 
@@ -33,6 +40,7 @@ Constants used in the tests:
 # Standard library imports
 from pathlib import Path
 import random
+import tempfile
 
 # Related third-party imports
 import unittest
@@ -49,6 +57,7 @@ from spezi_data_pipeline.data_processing.data_processor import (
     FHIRDataProcessor,
     select_data_by_dates,
     select_data_by_user,
+    extract_latest_user_interaction,
 )
 
 from spezi_data_pipeline.data_processing.observation_processor import (
@@ -163,6 +172,100 @@ class TestFHIRDataProcessor(unittest.TestCase):  # pylint: disable=unused-variab
             expected_number_of_rows,
             f"The number of rows after filtering should be exactly {expected_number_of_rows}.",
         )
+
+
+class TestExtractLatestUserInteraction(  # pylint: disable=unused-variable
+    unittest.TestCase
+):
+    """
+    This class contains unit tests for the extract_latest_user_interaction function, which
+    summarizes the most recent interaction recorded for each user in a FHIRDataFrame.
+    """
+
+    def setUp(self):
+        """Initialize sample interaction data spanning multiple users and dates."""
+        self.data = {
+            ColumnNames.USER_ID.value: [
+                "user1",
+                "user1",
+                "user2",
+                "user2",
+                "user2",
+            ],
+            ColumnNames.EFFECTIVE_DATE_TIME.value: [
+                "2023-01-01",
+                "2023-06-15",
+                "2023-03-10",
+                "2023-12-31",
+                "2023-11-01",
+            ],
+        }
+        self.fhir_df = FHIRDataFrame(
+            pd.DataFrame(self.data), resource_type=FHIRResourceType.OBSERVATION
+        )
+
+    def test_extract_latest_user_interaction(self):
+        """Verify that the latest interaction per user is returned."""
+        result_df = extract_latest_user_interaction(self.fhir_df)
+
+        self.assertEqual(len(result_df), 2)
+        self.assertListEqual(
+            list(result_df.columns),
+            [ColumnNames.USER_ID.value, ColumnNames.LAST_USER_INTERACTION.value],
+        )
+
+        latest_by_user = dict(
+            zip(
+                result_df[ColumnNames.USER_ID.value],
+                result_df[ColumnNames.LAST_USER_INTERACTION.value],
+            )
+        )
+        self.assertEqual(latest_by_user["user1"], pd.Timestamp("2023-06-15"))
+        self.assertEqual(latest_by_user["user2"], pd.Timestamp("2023-12-31"))
+
+    def test_extract_latest_user_interaction_does_not_mutate_input(self):
+        """Ensure the source FHIRDataFrame is left unchanged."""
+        extract_latest_user_interaction(self.fhir_df)
+        self.assertEqual(
+            list(self.fhir_df.df[ColumnNames.EFFECTIVE_DATE_TIME.value]),
+            self.data[ColumnNames.EFFECTIVE_DATE_TIME.value],
+        )
+
+    def test_extract_latest_user_interaction_writes_csv(self):
+        """Verify that the result is written to the specified output file."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_file_path = Path(tmp_dir) / "latest_interactions.csv"
+            result_df = extract_latest_user_interaction(
+                self.fhir_df, output_file_path=str(output_file_path)
+            )
+
+            self.assertTrue(output_file_path.exists())
+            written_df = pd.read_csv(output_file_path)
+            self.assertEqual(len(written_df), len(result_df))
+            self.assertListEqual(
+                list(written_df.columns),
+                [ColumnNames.USER_ID.value, ColumnNames.LAST_USER_INTERACTION.value],
+            )
+
+    def test_extract_latest_user_interaction_empty_input(self):
+        """Verify that an empty input yields an empty result and writes no file."""
+        empty_fhir_df = FHIRDataFrame(
+            pd.DataFrame(
+                columns=[
+                    ColumnNames.USER_ID.value,
+                    ColumnNames.EFFECTIVE_DATE_TIME.value,
+                ]
+            ),
+            resource_type=FHIRResourceType.OBSERVATION,
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_file_path = Path(tmp_dir) / "should_not_exist.csv"
+            result_df = extract_latest_user_interaction(
+                empty_fhir_df, output_file_path=str(output_file_path)
+            )
+
+            self.assertTrue(result_df.empty)
+            self.assertFalse(output_file_path.exists())
 
 
 class TestCalculateRiskScore(unittest.TestCase):  # pylint: disable=unused-variable


### PR DESCRIPTION
# Track active users in DB

## :recycle: Current situation & Problem
PR for #17


## :gear: Release Notes 
* Added function `extract_latest_user_interaction` to `data_processor.py` to track active users in the DB.


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
