### PR TITLE
Add exception handling for FHIR resource errors and extend quantity mappings in `code_mapping.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The dowloaded data can be then plotted using the following commands:
 
 ```python
 # Create a visualizer instance
-visualizer = DataVisualizer()
+visualizer = DataExplorer()
 
 # Set plotting configuration
 selected_users = ["User1","User2", "User3"]
@@ -217,7 +217,7 @@ In a similar way, we can download and flatten ECG recordings (LOINC code: 131329
 
 ```python
 # Create a visualizer instance
-visualizer = ECGVisualizer()
+visualizer = ECGExplorer()
 
 # Set plotting configuration
 selected_users = ["User1"]

--- a/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
+++ b/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
@@ -31,7 +31,7 @@ Functions:
     `get_code_mappings`: Retrieves mappings for a given LOINC code or custom code, supporting the
         translation of codes for FHIR resource creation and querying.
 """
-
+# pylint: disable=broad-exception-caught
 # Standard library imports
 import json
 import os
@@ -423,7 +423,8 @@ class ObservationCreator(ResourceCreator):
                 resource_obj = Observation.parse_raw(resource_str)
             except Exception as e:
                 print(
-                    f"[ERROR] Failed to parse Observation for user_id={user.id}, document_id={doc.id}"
+                    f"[ERROR] Failed to parse Observation for user_id={user.id}, "
+                    f"document_id={doc.id}"
                 )
                 print(f"Reason: {e}")
                 continue  # skip this document and go to the next one

--- a/src/spezi_data_pipeline/data_exploration/data_explorer.py
+++ b/src/spezi_data_pipeline/data_exploration/data_explorer.py
@@ -187,7 +187,7 @@ class DataExplorer:  # pylint: disable=unused-variable
         return figures
 
     def plot_combined(
-        self, df_loinc: pd.DataFrame, users_to_plot: list[str]
+        self, df_loinc: pd.DataFrame, users_to_plot: list[str], loinc_code: str
     ) -> plt.Figure:
         """
         Generates a combined static plot for multiple users. Each user's data
@@ -198,6 +198,7 @@ class DataExplorer:  # pylint: disable=unused-variable
         Parameters:
             df_loinc (DataFrame): A DataFrame filtered for a specific code.
             users_to_plot (list[str]): A list of user IDs to include in the plot.
+            loinc_code (str): The code that the plot is focusing on.
 
         Returns:
             matplotlib.figure.Figure: The figure object representing the combined plot.
@@ -215,7 +216,7 @@ class DataExplorer:  # pylint: disable=unused-variable
         )
         plt.title(
             f"{df_loinc[ColumnNames.QUANTITY_NAME.value].iloc[0]} "
-            f"{date_range_title}"
+            f"({loinc_code} {date_range_title}"
         )
         plt.xlabel("Date")
         plt.ylabel(

--- a/src/spezi_data_pipeline/data_exploration/data_explorer.py
+++ b/src/spezi_data_pipeline/data_exploration/data_explorer.py
@@ -187,7 +187,7 @@ class DataExplorer:  # pylint: disable=unused-variable
         return figures
 
     def plot_combined(
-        self, df_loinc: pd.DataFrame, users_to_plot: list[str], loinc_code: str
+        self, df_loinc: pd.DataFrame, users_to_plot: list[str]
     ) -> plt.Figure:
         """
         Generates a combined static plot for multiple users. Each user's data
@@ -198,7 +198,6 @@ class DataExplorer:  # pylint: disable=unused-variable
         Parameters:
             df_loinc (DataFrame): A DataFrame filtered for a specific code.
             users_to_plot (list[str]): A list of user IDs to include in the plot.
-            loinc_code (str): The code that the plot is focusing on.
 
         Returns:
             matplotlib.figure.Figure: The figure object representing the combined plot.

--- a/src/spezi_data_pipeline/data_exploration/data_explorer.py
+++ b/src/spezi_data_pipeline/data_exploration/data_explorer.py
@@ -142,7 +142,7 @@ class DataExplorer:  # pylint: disable=unused-variable
     def create_static_plot(self, fhir_dataframe: FHIRDataFrame) -> list:
         """
         Generates static plots based on the filtered FHIR data, offering combined or
-        individual plots for specified users and LOINC codes.
+        individual plots for specified users and codes.
 
         Parameters:
             fhir_dataframe (FHIRDataFrame): The `FHIRDataFrame` containing the data
@@ -196,9 +196,9 @@ class DataExplorer:  # pylint: disable=unused-variable
         visualization for comparative analysis.
 
         Parameters:
-            df_loinc (DataFrame): A DataFrame filtered for a specific LOINC code.
+            df_loinc (DataFrame): A DataFrame filtered for a specific code.
             users_to_plot (list[str]): A list of user IDs to include in the plot.
-            loinc_code (str): The LOINC code that the plot is focusing on.
+            loinc_code (str): The code that the plot is focusing on.
 
         Returns:
             matplotlib.figure.Figure: The figure object representing the combined plot.
@@ -216,7 +216,7 @@ class DataExplorer:  # pylint: disable=unused-variable
         )
         plt.title(
             f"{df_loinc[ColumnNames.QUANTITY_NAME.value].iloc[0]} "
-            f"for LOINC Code {loinc_code} {date_range_title}"
+            f"{date_range_title}"
         )
         plt.xlabel("Date")
         plt.ylabel(
@@ -239,16 +239,16 @@ class DataExplorer:  # pylint: disable=unused-variable
         Generates individual static plots for each specified user. For each user, their
         data is aggregated and plotted in a separate figure. This method is called to
         generate detailed plots for individual users, focusing on data related to a
-        specific LOINC code.
+        specific code.
 
         Parameters:
-            df_loinc (DataFrame): A `DataFrame` filtered for a specific LOINC code.
+            df_loinc (DataFrame): A `DataFrame` filtered for a specific code.
             user_id (str): The user ID for which to generate the plot.
-            loinc_code (str): The LOINC code that the plot is focusing on.
+            loinc_code (str): The code that the plot is focusing on.
 
         Returns:
             matplotlib.figure.Figure: The figure object representing the individual plot.
-            If no data is found for the specified user ID and LOINC code, returns None.
+            If no data is found for the specified user ID and code, returns None.
         """
         if user_id is None:
             print("User ID must be provided for individual plots.")
@@ -256,7 +256,7 @@ class DataExplorer:  # pylint: disable=unused-variable
 
         user_df = df_loinc[df_loinc[ColumnNames.USER_ID.value] == user_id]
         if user_df.empty:
-            print(f"No data found for user ID {user_id} and LOINC code {loinc_code}.")
+            print(f"No data found for user ID {user_id} and code {loinc_code}.")
             return None
 
         plt.figure(figsize=(10, 6), dpi=DEFAULT_DPI_VALUE)
@@ -725,8 +725,8 @@ def explore_total_records_number(  # pylint: disable=unused-variable
 
     plt.figure(figsize=(20, 10))
     ax = counts.plot(kind="bar", stacked=True, figsize=(20, 10))
-    plt.title("Number of Records by LOINC Code", fontsize=20)
-    plt.xlabel("LOINC Code", fontsize=20)
+    plt.title("Number of Records by Code", fontsize=20)
+    plt.xlabel("Code", fontsize=20)
     plt.ylabel("Count", fontsize=20)
     plt.xticks(rotation=45, ha="right", fontsize=16)
     plt.legend(

--- a/src/spezi_data_pipeline/data_processing/code_mapping.py
+++ b/src/spezi_data_pipeline/data_processing/code_mapping.py
@@ -98,6 +98,21 @@ class CodeProcessor:  # pylint: disable=unused-variable
                 "8867-4",
                 "http://loinc.org",
             ),
+            "HKQuantityTypeIdentifierPhysicalEffort": (
+                "Apple Physical Effort",
+                "HKQuantityTypeIdentifierPhysicalEffort",
+                "http://developer.apple.com/documentation/healthkit",
+            ),
+            "41981-2": (
+                "Calories burned",
+                "41981-2",
+                "http://loinc.org",
+            ),
+            "HKQuantityTypeIdentifierVO2Max": (
+                "VO2 Max",
+                "HKQuantityTypeIdentifierVO2Max",
+                "http://developer.apple.com/documentation/healthkit",
+            ),
         }
 
         # Maps LOINC codes and similar identifiers to processing functions

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -33,7 +33,6 @@ from unittest.mock import patch, MagicMock
 import json
 from fhir.resources.R4B.observation import Observation
 from fhir.resources.R4B.questionnaireresponse import QuestionnaireResponse
-import pytest
 
 # Local application/library specific imports
 from spezi_data_pipeline.data_access.firebase_fhir_data_access import (
@@ -231,8 +230,11 @@ def test_get_code_mappings_returns_none_for_unknown_code(capfd):
 # --- Test for ResourceCreator NotImplementedError ---
 def test_resource_creator_not_implemented():
     rc = ResourceCreator("dummy")
-    with pytest.raises(NotImplementedError):
+    try:
         rc.create_resources([], None)
+        assert False, "NotImplementedError not raised"
+    except NotImplementedError:
+        pass
 
 
 class TestObservationCreator(unittest.TestCase):


### PR DESCRIPTION
# *Add exception handling for FHIR resource errors and extend quantity mappings in `code_mapping.py`*

## :gear: Release Notes
- Added error handling for unexpected or invalid data types encountered when parsing FHIR resources using `fhir.resources`.
- Added new entries to `code_mapping.py` to support additional HealthKit and LOINC identifiers:

```
"HKQuantityTypeIdentifierPhysicalEffort": (
    "Apple Physical Effort",
    "HKQuantityTypeIdentifierPhysicalEffort",
    "http://developer.apple.com/documentation/healthkit",
),
"41981-2": (
    "Calories burned",
    "41981-2",
    "http://loinc.org",
),
"HKQuantityTypeIdentifierVO2Max": (
    "VO2 Max",
    "HKQuantityTypeIdentifierVO2Max",
    "http://developer.apple.com/documentation/healthkit",
)
```

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
