### PR TITLE
Migrate deprecated Pydantic v1 methods to v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "numpy>=1.20.0",
     "matplotlib>=3.4.0",
     "firebase-admin>=5.0.0",
-    "fhir.resources>=6.0.0"
+    "fhir.resources>=8.0,<9"
 ]
 [[project.authors]]
 name = "Full Name"   # The authors' list is automatically updated by the update_authors.py script

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas
 numpy
 matplotlib
 firebase-admin
-fhir.resources
+fhir.resources>=8.0,<9
 pytest>=7.0
 coverage
 pytest-cov>=2.10.0

--- a/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
+++ b/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
@@ -435,7 +435,7 @@ class ObservationCreator(ResourceCreator):
 
             try:
                 resource_str = json.dumps(doc_dict)
-                resource_obj = Observation.parse_raw(resource_str)
+                resource_obj = Observation.model_validate_json(resource_str)
             except Exception as e:
                 print(
                     f"[ERROR] Failed to parse Observation for user_id={user.id}, "
@@ -508,7 +508,7 @@ class QuestionnaireResponseCreator(ResourceCreator):
         for doc in fhir_docs:
             doc_dict = doc.to_dict()
             resource_str = json.dumps(doc_dict)
-            resource_obj = QuestionnaireResponse.parse_raw(resource_str)
+            resource_obj = QuestionnaireResponse.model_validate_json(resource_str)
             if user:
                 resource_obj.subject = Reference(id=user.id)
             resources.append(resource_obj)

--- a/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
+++ b/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
@@ -481,11 +481,11 @@ class ObservationFlattener(ResourceFlattener):
         for observation in resources:
 
             if not (
-                effective_datetime := observation.dict().get(
+                effective_datetime := observation.model_dump().get(
                     KeyNames.EFFECTIVE_DATE_TIME.value
                 )
             ):
-                effective_period = observation.dict().get(
+                effective_period = observation.model_dump().get(
                     KeyNames.EFFECTIVE_PERIOD.value, {}
                 )
                 effective_datetime = effective_period.get(KeyNames.START.value, None)
@@ -502,10 +502,10 @@ class ObservationFlattener(ResourceFlattener):
                     effective_datetime if effective_datetime else None
                 ),
                 **coding_info,
-                ColumnNames.QUANTITY_UNIT.value: observation.dict()
+                ColumnNames.QUANTITY_UNIT.value: observation.model_dump()
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.UNIT.value, None),
-                ColumnNames.QUANTITY_VALUE.value: observation.dict()
+                ColumnNames.QUANTITY_VALUE.value: observation.model_dump()
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.VALUE.value, None),
             }
@@ -563,11 +563,11 @@ class ECGObservationFlattener(ResourceFlattener):
         for observation in resources:
 
             if not (
-                effective_datetime := observation.dict().get(
+                effective_datetime := observation.model_dump().get(
                     KeyNames.EFFECTIVE_DATE_TIME.value
                 )
             ):
-                effective_period = observation.dict().get(
+                effective_period = observation.model_dump().get(
                     KeyNames.EFFECTIVE_PERIOD.value, {}
                 )
                 effective_datetime = effective_period.get(KeyNames.START.value, None)
@@ -583,26 +583,26 @@ class ECGObservationFlattener(ResourceFlattener):
                 ColumnNames.USER_ID.value: subject_id,
                 ColumnNames.RESOURCE_ID.value: observation.id,
                 ColumnNames.EFFECTIVE_DATE_TIME.value: effective_datetime,
-                ColumnNames.NUMBER_OF_MEASUREMENTS.value: observation.dict()
+                ColumnNames.NUMBER_OF_MEASUREMENTS.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[0]
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.VALUE.value, None),
-                ColumnNames.SAMPLING_FREQUENCY.value: observation.dict()
+                ColumnNames.SAMPLING_FREQUENCY.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[1]
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.VALUE.value, None),
-                ColumnNames.SAMPLING_FREQUENCY_UNIT.value: observation.dict()
+                ColumnNames.SAMPLING_FREQUENCY_UNIT.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[1]
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.UNIT.value, None),
-                ColumnNames.APPLE_ELECTROCARDIOGRAM_CLASSIFICATION.value: observation.dict()
+                ColumnNames.APPLE_ELECTROCARDIOGRAM_CLASSIFICATION.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[2]
                 .get(KeyNames.VALUE_STRING.value, None),
-                ColumnNames.HEART_RATE.value: observation.dict()
+                ColumnNames.HEART_RATE.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[3]
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.VALUE.value, None),
-                ColumnNames.HEART_RATE_UNIT.value: observation.dict()
+                ColumnNames.HEART_RATE_UNIT.value: observation.model_dump()
                 .get(KeyNames.COMPONENT.value, [{}])[3]
                 .get(KeyNames.VALUE_QUANTITY.value, {})
                 .get(KeyNames.UNIT.value, None),
@@ -639,7 +639,7 @@ def extract_coding_info(observation: Observation | ECGObservation) -> dict:
             Apple HealthKit code, and display text.
     """
     coding = (
-        observation.dict().get(KeyNames.CODE.value, {}).get(KeyNames.CODING.value, [])
+        observation.model_dump().get(KeyNames.CODE.value, {}).get(KeyNames.CODING.value, [])
     )
 
     loinc_code = None
@@ -686,7 +686,7 @@ def extract_component_info(observation: ECGObservation) -> dict:
         including a single merged ECG recording data string and the unit of measurement.
     """
     component_info = {}
-    components = observation.dict().get(KeyNames.COMPONENT.value, [])
+    components = observation.model_dump().get(KeyNames.COMPONENT.value, [])
 
     merged_ecg_data = ""
     unit = None

--- a/tests/test_data_flattening.py
+++ b/tests/test_data_flattening.py
@@ -398,7 +398,7 @@ def create_mock_observations() -> list[Observation] | str:
 
                 resource_str = json.dumps(data)
 
-                resource_obj = Observation.parse_raw(resource_str)
+                resource_obj = Observation.model_validate_json(resource_str)
                 resource_obj.subject = Reference(id="XrftRMc358NndzcRWEQ7P2MxvabZ")
 
                 observations.append(resource_obj)
@@ -446,7 +446,7 @@ def create_mock_ecg_observations() -> list[ECGObservation] | str:
 
                 resource_str = json.dumps(data)
 
-                resource_obj = Observation.parse_raw(resource_str)
+                resource_obj = Observation.model_validate_json(resource_str)
                 resource_obj.subject = Reference(id="3aX1qRKWQKTRDQZqr5vg5N7yWU12")
                 ecg_resource_obj = ECGObservation(resource_obj)
                 ecg_observations.append(ecg_resource_obj)
@@ -482,7 +482,7 @@ def create_mock_questionnaire_responses() -> list[QuestionnaireResponse] | str:
 
                 resource_str = json.dumps(data)
 
-                resource_obj = QuestionnaireResponse.parse_raw(resource_str)
+                resource_obj = QuestionnaireResponse.model_validate_json(resource_str)
                 resource_obj.subject = Reference(id="5tTYsEWMIKNq4EJEf24suVINGI12")
 
                 questionnaire_responses.append(resource_obj)


### PR DESCRIPTION
`fhir.resources` is on Pydantic v2 now, which deprecates `parse_raw()` and `.dict()` — both are removed in Pydantic v3. Switched to the v2 equivalents so this doesn't break when v3 lands:

- `parse_raw()` → `model_validate_json()`
- `.dict()` → `.model_dump()`

No behavior change — the old methods already just proxy to these under v2. Tests pass and the deprecation warnings are gone.