### PR TITLE
Enforce Black formatting in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,9 +44,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install Black
-        run: pip install black[jupyter]
+        run: pip install black[jupyter]==26.5.1
       - name: Check code formatting with Black
-        run: black . --exclude '\.ipynb$'
+        run: black --check . --exclude '\.ipynb$'
   unit_tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/scripts/update_authors.py
+++ b/scripts/update_authors.py
@@ -10,12 +10,12 @@
 This script updates the 'authors' section of the pyproject.toml file based on the CONTRIBUTORS.md
 file.
 
-It parses the CONTRIBUTORS.md file to extract the list of contributors and updates the 
+It parses the CONTRIBUTORS.md file to extract the list of contributors and updates the
 pyproject.toml file to reflect these contributors in the 'authors' section.
 
 Functions:
 - parse_contributors(file_path): Parses the CONTRIBUTORS.md file to extract author names.
-- update_pyproject_toml(pyproject_path, contributors): Updates the pyproject.toml file with the 
+- update_pyproject_toml(pyproject_path, contributors): Updates the pyproject.toml file with the
     list of authors.
 """
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -9,23 +9,23 @@
 """
 Module to automatically update the Hatch project version based on the latest Git tag.
 
-This module contains functions to retrieve the latest Git tag and update the 
-Hatch version in the `pyproject.toml` configuration file. The script is intended 
+This module contains functions to retrieve the latest Git tag and update the
+Hatch version in the `pyproject.toml` configuration file. The script is intended
 to be run as a standalone program.
 
 Functions:
     get_latest_git_tag(): Retrieves the latest Git tag from the repository.
-    update_hatch_version(tag): Updates the version in the Hatch configuration file 
+    update_hatch_version(tag): Updates the version in the Hatch configuration file
                                with the specified tag.
 
 Usage:
-    Run this script from the command line to automatically update the version in 
+    Run this script from the command line to automatically update the version in
     the `pyproject.toml` file based on the latest Git tag:
-    
+
     $ python script_name.py
-    
-    The script will validate that the tag is in a valid semantic versioning format 
-    (e.g., "1.0.0"). If the tag is valid, it will update the version in 
+
+    The script will validate that the tag is in a valid semantic versioning format
+    (e.g., "1.0.0"). If the tag is valid, it will update the version in
     `pyproject.toml`. If the tag is not valid, it will print an error message.
 """
 

--- a/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
+++ b/src/spezi_data_pipeline/data_access/firebase_fhir_data_access.py
@@ -31,6 +31,7 @@ Functions:
     `get_code_mappings`: Retrieves mappings for a given LOINC code or custom code, supporting the
         translation of codes for FHIR resource creation and querying.
 """
+
 # pylint: disable=broad-exception-caught
 # Standard library imports
 import json

--- a/src/spezi_data_pipeline/data_exploration/data_explorer.py
+++ b/src/spezi_data_pipeline/data_exploration/data_explorer.py
@@ -54,7 +54,6 @@ from spezi_data_pipeline.data_flattening.fhir_resources_flattener import (
     ColumnNames,
 )
 
-
 TIME_UNIT = "sec"
 ECG_MICROVOLT_UNIT = "uV"
 ECG_MILLIVOLT_UNIT = "mV"
@@ -739,4 +738,4 @@ def explore_total_records_number(  # pylint: disable=unused-variable
     plt.tight_layout()
     plt.show()
 
-    return ax # For test inspection
+    return ax  # For test inspection

--- a/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
+++ b/src/spezi_data_pipeline/data_flattening/fhir_resources_flattener.py
@@ -33,7 +33,7 @@ Main Components:
                                     mapping questions and answers to their respective text using
                                     Phoenix-generated questionnaire JSON files.
 
-- `get_answer_code_and_value`: Retrieves the answer code and text for a given item from the 
+- `get_answer_code_and_value`: Retrieves the answer code and text for a given item from the
                                `QuestionnaireResponse`.
 - `extract_questionnaire_mappings`: Extracts question and answer mappings from a FHIR Questionnaire
                                     JSON file for easy lookup.
@@ -56,7 +56,6 @@ import pandas as pd
 from fhir.resources.R4B.observation import Observation
 from fhir.resources.R4B.questionnaireresponse import QuestionnaireResponse
 from fhir.resources.R4B.questionnaireresponse import QuestionnaireResponseItem
-
 
 ENCODING = "utf-8"
 EXT_URL_ORDINAL_VALUE_STRING = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
@@ -639,7 +638,9 @@ def extract_coding_info(observation: Observation | ECGObservation) -> dict:
             Apple HealthKit code, and display text.
     """
     coding = (
-        observation.model_dump().get(KeyNames.CODE.value, {}).get(KeyNames.CODING.value, [])
+        observation.model_dump()
+        .get(KeyNames.CODE.value, {})
+        .get(KeyNames.CODING.value, [])
     )
 
     loinc_code = None

--- a/src/spezi_data_pipeline/data_processing/observation_processor.py
+++ b/src/spezi_data_pipeline/data_processing/observation_processor.py
@@ -7,10 +7,10 @@
 #
 
 """
-This module provides a collection of functions designed for the processing of observations 
+This module provides a collection of functions designed for the processing of observations
 represented in the FHIR (Fast Healthcare Interoperability Resources) format. It includes
 capabilities for aggregating data by day, calculating averages, and applying moving averages
-to smooth out time-series data. These functions facilitate the examination of trends and patterns 
+to smooth out time-series data. These functions facilitate the examination of trends and patterns
 in health metrics over time, making it easier for healthcare professionals, researchers, and
 data analysts to derive insights from complex datasets.
 

--- a/src/spezi_data_pipeline/data_processing/questionnaire_processor.py
+++ b/src/spezi_data_pipeline/data_processing/questionnaire_processor.py
@@ -9,8 +9,8 @@
 """
 Module for calculating risk scores based on various health questionnaires using FHIR resources.
 
-This module defines enumerations for different levels of severity for depression, anxiety, 
-and impairment. It includes functions to calculate risk scores for specific questionnaires 
+This module defines enumerations for different levels of severity for depression, anxiety,
+and impairment. It includes functions to calculate risk scores for specific questionnaires
 like PHQ-9, GAD-7, and WIQ, using the FHIRDataFrame structure from the Spezi data pipeline.
 
 Classes:
@@ -371,7 +371,5 @@ def calculate_risk_score(  # pylint: disable=unused-variable
             return func(fhir_dataframe, severity_enum)
 
     available_options = ", ".join(calculation_functions.keys())
-    raise ValueError(
-        f"Unsupported questionnaire title: {questionnaire_title}. \
-                        Available options: {available_options}"
-    )
+    raise ValueError(f"Unsupported questionnaire title: {questionnaire_title}. \
+                        Available options: {available_options}")

--- a/tests/test_data_flattening.py
+++ b/tests/test_data_flattening.py
@@ -237,7 +237,8 @@ class TestQuestionnaireResponseFlattener(  # pylint: disable=unused-variable
 
         flattener = QuestionnaireResponseFlattener()
         result = flattener.flatten(
-            resources, questionnaire_resource_path="Resources/SocialSupportQuestionnaire.json"
+            resources,
+            questionnaire_resource_path="Resources/SocialSupportQuestionnaire.json",
         )
 
         self.assertIsNotNone(result, "The resulting DataFrame should not be None")

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -7,8 +7,8 @@
 #
 
 """
-This module contains unit tests for various components of the Spezi Data Pipeline, 
-focusing on the processing and analysis of FHIR (Fast Healthcare Interoperability Resources) data. 
+This module contains unit tests for various components of the Spezi Data Pipeline,
+focusing on the processing and analysis of FHIR (Fast Healthcare Interoperability Resources) data.
 The tests ensure the correct functionality of key data processing methods, including outlier
 filtering, user-specific data selection, date-specific data selection, and the calculation of
 risk scores from  questionnaire responses.

--- a/tests/test_update_configuration_file.py
+++ b/tests/test_update_configuration_file.py
@@ -13,25 +13,26 @@ configuration file.
 This module contains unit tests for:
 1. Parsing authors from the `CONTRIBUTORS.md` file and updating the `pyproject.toml`
     configuration file.
-2. Retrieving the latest Git tag and updating the version in the pyproject.toml`  
+2. Retrieving the latest Git tag and updating the version in the pyproject.toml`
     configuration file.
 
 Classes:
-    `TestContributorsFunctions`: Contains unit tests for parsing and updating contributors 
+    `TestContributorsFunctions`: Contains unit tests for parsing and updating contributors
                                in the `pyproject.toml file`.
-    `TestVersionFunctions`: Contains unit tests for the functions `get_latest_git_tag` and 
+    `TestVersionFunctions`: Contains unit tests for the functions `get_latest_git_tag` and
                           `update_hatch_version`.
 
 Functions:
-    `test_parse_contributors(self)`: Tests parsing of authors from the `CONTRIBUTORS.md` file in 
+    `test_parse_contributors(self)`: Tests parsing of authors from the `CONTRIBUTORS.md` file in
                                    `TestContributorsFunctions`.
     `test_update_pyproject_toml(self)`: Tests updating of the `pyproject.toml` file with parsed
                                         authors in `TestContributorsFunctions`.
     `test_get_latest_git_tag(self, mock_run)`: Tests the retrieval of the latest Git tag using the
                                                git command in `TestVersionFunctions`.
-    `test_update_hatch_version(self, mock_file)`: Tests the updating of the hatch version in the 
+    `test_update_hatch_version(self, mock_file)`: Tests the updating of the hatch version in the
                                                 `pyproject.toml` file in `TestVersionFunctions`.
 """
+
 # Related third-party imports
 import unittest
 from unittest.mock import mock_open, patch


### PR DESCRIPTION
The Black check ran `black .` (reformat mode), which rewrites files in the runner and always exits 0 — so it never actually enforced anything, and the repo had drifted (10 files).

This reformats the repo with Black 26.5.1 and switches the CI step to `black --check`, pinning the version so the gate is deterministic. The reformat is whitespace/wrapping only — no logic changes.